### PR TITLE
Fix compatibility issue with jupyterhub > 0.7

### DIFF
--- a/imagespawner/imagespawner.py
+++ b/imagespawner/imagespawner.py
@@ -74,10 +74,12 @@ class DockerImageChooserSpawner(DockerSpawner):
         self.container_prefix = self.user_options['container_prefix']
 
         # start the container
-        yield DockerSpawner.start(
+        ret = yield DockerSpawner.start(
             self, image=self.user_options['container_image'],
             extra_create_kwargs=extra_create_kwargs,
             extra_host_config=extra_host_config)
-    
+        self.log.info('Started service at %s:%d' % ret)
+        return ret
+
 # http://jupyter.readthedocs.io/en/latest/development_guide/coding_style.html
 # vim: set ai et ts=4 sw=4:


### PR DESCRIPTION
For jupyterhub >= 0.7, the `start()` function is expected to return `(ip, port)` instead of store ip and port to object property. 

See also https://github.com/jupyterhub/dockerspawner/blob/19e26f3d1f5fd196b2a750f9e9c525bcfa0c95fb/dockerspawner/dockerspawner.py#L583 